### PR TITLE
Reverted to use BeatSaver download URL

### DIFF
--- a/src/lib/BeatSaverAPI.ts
+++ b/src/lib/BeatSaverAPI.ts
@@ -24,7 +24,7 @@ export default class BeatSaverAPI {
   }
 
   public static getDownloadUrlFor(beatmap: ISongOnline) {
-    return WEBSITE_BASE_URL + (beatmap.directDownload || beatmap.downloadURL);
+    return WEBSITE_BASE_URL + beatmap.downloadURL;
   }
 
   public http: AxiosInstance;


### PR DESCRIPTION
as opposed to the direct download URL

BeatSaver is on a new server, so using the direct download is no longer necessary.