### PR TITLE
adjust naming convention to match BeatSaverDownloader

### DIFF
--- a/src/libraries/os/beatSaber/BeatSaber.ts
+++ b/src/libraries/os/beatSaber/BeatSaber.ts
@@ -86,7 +86,7 @@ export default class BeatSaber {
     const songName = purgeText(beatmap.metadata.songName);
     const levelAuthorName = purgeText(beatmap.metadata.levelAuthorName);
 
-    const beatmapFolder = `${key} ${songName} - ${levelAuthorName}`;
+    const beatmapFolder = `${key} (${songName} - ${levelAuthorName})`;
 
     return path.join(installationPath, BEAT_SABER_CUSTOM_LEVEL, beatmapFolder);
   }


### PR DESCRIPTION
BeatSaverDownloader and ModAssistant follow the naming convention "key (songName - levelAuthorName)" to help prevent duplicate songs from being downloaded, especially now that ModAssistant also supports playlist downloading