### PR TITLE
WIP: Add playlist tab to beatmap table, implements #40

### DIFF
--- a/src/components/beatmap/PlaylistThumbnails.vue
+++ b/src/components/beatmap/PlaylistThumbnails.vue
@@ -1,16 +1,14 @@
 <template>
-  <v-container :class="'pa-0 pl-3'">
-    <v-tooltip v-for="value in playlists" :key="value.key" top>
+  <v-container class="pa-0 pl-3">
+    <v-tooltip v-for="playlist in playlists" :key="playlist.key" top>
       <template #activator="{ on }">
         <v-chip :v-on="on" color="transparent">
-          <PlaylistCoverAvatar
-            :playlist="value"
-            :avatar-size="24"
-            :icon-expand-size="16"
-          />
+          <v-avatar :size="24" class="mx-1" v-on="on">
+            <PlaylistCover :playlist="playlist" />
+          </v-avatar>
         </v-chip>
       </template>
-      <span>{{ value.title }}</span>
+      <span>{{ playlist.title }}</span>
     </v-tooltip>
   </v-container>
 </template>
@@ -19,12 +17,12 @@
 import Vue from "vue";
 import BeatmapLibrary from "@/libraries/beatmap/BeatmapLibrary";
 import { PlaylistLocal } from "@/libraries/playlist/PlaylistLocal";
-import PlaylistCoverAvatar from "@/components/playlist/cover/PlaylistCoverAvatar.vue";
+import PlaylistCover from "@/components/playlist/cover/PlaylistCoverAvatar.vue";
 
 export default Vue.extend({
   name: "PlaylistThumbnails",
   components: {
-    PlaylistCoverAvatar,
+    PlaylistCover,
   },
   props: {
     item: { type: Object, required: true },

--- a/src/components/beatmap/PlaylistThumbnails.vue
+++ b/src/components/beatmap/PlaylistThumbnails.vue
@@ -1,0 +1,38 @@
+<template>
+  <v-container :class="'pa-0 pl-3'">
+    <v-tooltip v-for="value in playlists" :key="value.key" top>
+      <template #activator="{ on }">
+        <v-chip :v-on="on" color="transparent">
+          <PlaylistCoverAvatar
+            :playlist="value"
+            :avatar-size="24"
+            :icon-expand-size="16"
+          />
+        </v-chip>
+      </template>
+      <span>{{ value.title }}</span>
+    </v-tooltip>
+  </v-container>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import BeatmapLibrary from "@/libraries/beatmap/BeatmapLibrary";
+import { PlaylistLocal } from "@/libraries/playlist/PlaylistLocal";
+import PlaylistCoverAvatar from "@/components/playlist/cover/PlaylistCoverAvatar.vue";
+
+export default Vue.extend({
+  name: "PlaylistThumbnails",
+  components: {
+    PlaylistCoverAvatar,
+  },
+  props: {
+    item: { type: Object, required: true },
+  },
+  computed: {
+    playlists(): PlaylistLocal[] {
+      return BeatmapLibrary.GetPlaylists(this.item.data);
+    },
+  },
+});
+</script>

--- a/src/components/beatmap/table/BeatmapsTable.vue
+++ b/src/components/beatmap/table/BeatmapsTable.vue
@@ -121,6 +121,7 @@ import BeatmapsTableTemplateTextTooltip from "@/components/beatmap/table/core/te
 import BeatmapsTableTemplateBeatmapName from "@/components/beatmap/table/core/template/BeatmapsTableTemplateBeatmapName.vue";
 import BeatmapsTableTemplateStrToDate from "@/components/beatmap/table/core/template/BeatmapsTableTemplateStrToDate.vue";
 import BeatmapsTableTemplateDifficulties from "@/components/beatmap/table/core/template/BeatmapsTableTemplateDifficulties.vue";
+import BeatmapsTableTemplatePlaylists from "@/components/beatmap/table/core/template/BeatmapsTableTemplatePlaylists.vue";
 import BeatmapsTableTemplateRating from "@/components/beatmap/table/core/template/BeatmapsTableTemplateRating.vue";
 import BeatmapsTableColumnSelector from "@/components/beatmap/table/core/BeatmapsTableColumnSelector.vue";
 import BeatmapsTableFooter from "@/components/beatmap/table/core/BeatmapsTableFooter.vue";
@@ -135,6 +136,7 @@ export default Vue.extend({
     BeatmapsTableTemplateCover,
     BeatmapsTableTemplateText,
     BeatmapsTableTemplateDifficulties,
+    BeatmapsTableTemplatePlaylists,
     BeatmapsTableTemplateTextTooltip,
     BeatmapsTableTemplateBeatmapName,
     BeatmapsTableTemplateStrToDate,
@@ -248,6 +250,15 @@ export default Vue.extend({
           filterable: true,
           localFilter: (value) =>
             FilterDifficulties(value, this.filtersValue.difficulties),
+          width: 110,
+        },
+        {
+          value: "playlists",
+          text: "Playlists",
+          template: BeatmapsTableHeadersTemplate.Playlists,
+          align: "left",
+          sortable: false,
+          filterable: false,
           width: 110,
         },
         {

--- a/src/components/beatmap/table/core/BeatmapsTableColumnSelector.vue
+++ b/src/components/beatmap/table/core/BeatmapsTableColumnSelector.vue
@@ -34,6 +34,7 @@ export default Vue.extend({
       { value: "artist", text: "Artist" },
       { value: "mapper", text: "Mapper" },
       { value: "difficulties", text: "Difficulties" },
+      { value: "playlists", text: "Playlists" },
       { value: "dl", text: "Downloads" },
       { value: "plays", text: "Plays" },
       { value: "upvotes", text: "Up votes" },

--- a/src/components/beatmap/table/core/BeatmapsTableHeaders.ts
+++ b/src/components/beatmap/table/core/BeatmapsTableHeaders.ts
@@ -2,6 +2,7 @@ export enum BeatmapsTableHeadersTemplate {
   Text = "Text",
   Cover = "Cover",
   Difficulties = "Difficulties",
+  Playlists = "Playlists",
   StrToDate = "StrToDate",
   TextTooltip = "TextTooltip",
   BeatmapName = "BeatmapName",

--- a/src/components/beatmap/table/core/template/BeatmapsTableTemplatePlaylists.vue
+++ b/src/components/beatmap/table/core/template/BeatmapsTableTemplatePlaylists.vue
@@ -1,0 +1,16 @@
+<template>
+  <PlaylistThumbnails :item="item" />
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import PlaylistThumbnails from "@/components/beatmap/PlaylistThumbnails.vue";
+
+export default Vue.extend({
+  name: "BeatmapsTableTemplatePlaylists",
+  components: { PlaylistThumbnails },
+  props: {
+    item: { type: Object, required: true },
+  },
+});
+</script>

--- a/src/libraries/beatmap/BeatmapLibrary.ts
+++ b/src/libraries/beatmap/BeatmapLibrary.ts
@@ -4,6 +4,8 @@ import { BeatmapLocal } from "@/libraries/beatmap/BeatmapLocal";
 import { BeatsaverBeatmap } from "@/libraries/net/beatsaver/BeatsaverBeatmap";
 import { BeatmapsTableDataUnit } from "@/components/beatmap/table/core/BeatmapsTableDataUnit";
 import BeatsaverCachedLibrary from "@/libraries/beatmap/repo/BeatsaverCachedLibrary";
+import PlaylistLibrary from "../playlist/PlaylistLibrary";
+import { PlaylistLocal } from "../playlist/PlaylistLocal";
 
 export default class BeatmapLibrary {
   public static GetAllMaps(): BeatmapLocal[] {
@@ -63,5 +65,19 @@ export default class BeatmapLibrary {
 
   public static RemoveBeatmap(beatmap: BeatmapLocal) {
     store.commit("beatmap/removeBeatmap", { beatmap });
+  }
+
+  public static GetPlaylists(beatmap: BeatmapLocal): PlaylistLocal[] {
+    const affiliatedPlaylists: PlaylistLocal[] = [];
+    PlaylistLibrary.GetAllValidPlaylists().forEach((playlist) => {
+      playlist.maps.some((map) => {
+        if (map.hash !== undefined && map.hash === beatmap.hash) {
+          affiliatedPlaylists.push(playlist);
+          return true;
+        }
+        return false;
+      });
+    });
+    return affiliatedPlaylists;
   }
 }

--- a/src/libraries/beatmap/BeatmapLibrary.ts
+++ b/src/libraries/beatmap/BeatmapLibrary.ts
@@ -70,13 +70,12 @@ export default class BeatmapLibrary {
   public static GetPlaylists(beatmap: BeatmapLocal): PlaylistLocal[] {
     const affiliatedPlaylists: PlaylistLocal[] = [];
     PlaylistLibrary.GetAllValidPlaylists().forEach((playlist) => {
-      playlist.maps.some((map) => {
+      for (const map of playlist.maps) {
         if (map.hash !== undefined && map.hash === beatmap.hash) {
           affiliatedPlaylists.push(playlist);
-          return true;
+          break;
         }
-        return false;
-      });
+      }
     });
     return affiliatedPlaylists;
   }

--- a/src/libraries/beatmap/BeatmapLibrary.ts
+++ b/src/libraries/beatmap/BeatmapLibrary.ts
@@ -68,15 +68,10 @@ export default class BeatmapLibrary {
   }
 
   public static GetPlaylists(beatmap: BeatmapLocal): PlaylistLocal[] {
-    const affiliatedPlaylists: PlaylistLocal[] = [];
-    PlaylistLibrary.GetAllValidPlaylists().forEach((playlist) => {
-      for (const map of playlist.maps) {
-        if (map.hash !== undefined && map.hash === beatmap.hash) {
-          affiliatedPlaylists.push(playlist);
-          break;
-        }
-      }
-    });
-    return affiliatedPlaylists;
+    return PlaylistLibrary.GetAllValidPlaylists().filter((playlist) =>
+      playlist.maps.find(
+        (map) => map.hash !== undefined && map.hash === beatmap.hash
+      )
+    );
   }
 }


### PR DESCRIPTION
This adds a new tab in the local beatmap data table that displays the thumbnails of all playlists the respective beatmap is a part of, as was suggested in #40.  

As I am totally unfamiliar with vue itself I might not adhere to common best practices, if anything stands out let me know.
One thing I was not able to do is overlapping the thumbnails, like your difficulty chips do. I would suppose with some familiarity this should be a two minute fix, so I'd appreciate a pointer in the right direction.

I'm on your discord with the username AngryEndUser, so you can message me over there if you like. 