### PR TITLE
Playlist cover perf

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beatlist",
   "description": "App to create playlist for BeatSaber",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "homepage": "https://github.com/Alaanor/beatlist",
   "repository": {
     "type": "git",

--- a/src/libraries/app/UpgradeCheckerService.ts
+++ b/src/libraries/app/UpgradeCheckerService.ts
@@ -2,6 +2,7 @@ import { remote } from "electron";
 import semver from "semver";
 import localforage from "localforage";
 import store from "@/plugins/store";
+import MigrateTo123 from "@/libraries/app/migration/MigrationVersion1.2.3";
 
 export default class UpgradeCheckerService {
   public static async Initialize() {
@@ -22,8 +23,18 @@ export default class UpgradeCheckerService {
     }
 
     if (isNewVersion) {
+      if (previousVersion !== undefined) {
+        UpgradeCheckerService.UpgradeFor(previousVersion);
+      }
+
       store.commit("modal/SET_NEW_VERSION_MODAL", true);
       store.commit("settings/SET_APP_VERSION", currentVersion);
+    }
+  }
+
+  private static UpgradeFor(previousVersion: string) {
+    if (semver.gt("1.2.3", previousVersion)) {
+      MigrateTo123();
     }
   }
 

--- a/src/libraries/app/migration/MigrationVersion1.2.3.ts
+++ b/src/libraries/app/migration/MigrationVersion1.2.3.ts
@@ -1,0 +1,13 @@
+import store from "@/plugins/store";
+import PlaylistLibrary from "@/libraries/playlist/PlaylistLibrary";
+
+export default () => {
+  const allPlaylist = PlaylistLibrary.GetAllPlaylists();
+  const allPlaylistWithoutCover = allPlaylist.map((playlist) => {
+    const copy = { ...playlist };
+    copy.cover = null;
+    return copy;
+  });
+
+  store.commit("playlist/SET_PLAYLISTS", allPlaylistWithoutCover);
+};

--- a/src/libraries/playlist/PlaylistLibrary.ts
+++ b/src/libraries/playlist/PlaylistLibrary.ts
@@ -35,6 +35,11 @@ export default class PlaylistLibrary {
   }
 
   public static UpdateAllPlaylist(playlists: PlaylistLocal[]) {
+    playlists = playlists.map((playlist) => {
+      const copy = { ...playlist };
+      copy.cover = null;
+      return copy;
+    });
     store.commit("playlist/SET_LAST_SCAN", new Date());
     store.commit("playlist/SET_PLAYLISTS", playlists);
   }

--- a/src/libraries/playlist/loader/PlaylistLoader.ts
+++ b/src/libraries/playlist/loader/PlaylistLoader.ts
@@ -89,6 +89,10 @@ export default class PlaylistLoader {
     await serializer.serialize(playlist);
   }
 
+  public static LoadCover(playlistPath: string): Promise<Buffer | null> {
+    return this.GetPlaylistBase(playlistPath).then((p) => p.cover);
+  }
+
   private static async GetPlaylistBase(
     filepath: string,
     progress?: Progress

--- a/src/pages/playlists/local/components/PlaylistEditorDetails.vue
+++ b/src/pages/playlists/local/components/PlaylistEditorDetails.vue
@@ -139,6 +139,7 @@ import Base64SrcLoader from "@/libraries/os/utils/Base64SrcLoader";
 import ConfirmDialog from "@/components/dialogs/ConfirmDialog.vue";
 import PlaylistOperation from "@/libraries/playlist/PlaylistOperation";
 import PlaylistFormatType from "@/libraries/playlist/PlaylistFormatType";
+import PlaylistLoader from "@/libraries/playlist/loader/PlaylistLoader";
 
 export default Vue.extend({
   name: "PlaylistEditorDetails",
@@ -182,9 +183,14 @@ export default Vue.extend({
   methods: {
     async LoadCover() {
       this.imageChanged = false;
+      let { cover } = this.playlist;
 
-      if (this.playlist.cover) {
-        this.imageData = Base64SrcLoader.FromBuffer(this.playlist.cover, "png");
+      if (!cover && this.playlist.path) {
+        cover = await PlaylistLoader.LoadCover(this.playlist.path);
+      }
+
+      if (cover) {
+        this.imageData = Base64SrcLoader.FromBuffer(cover, "png");
       } else {
         this.imageData = "";
       }

--- a/src/store/playlist.ts
+++ b/src/store/playlist.ts
@@ -21,7 +21,9 @@ const mutations = {
     context: PlaylistStoreState,
     payload: { playlist: PlaylistLocal }
   ) {
-    context.playlists.push(payload.playlist);
+    const copy = { ...payload.playlist };
+    copy.cover = null;
+    context.playlists.push(copy);
   },
   removePlaylist(
     context: PlaylistStoreState,
@@ -38,7 +40,10 @@ const mutations = {
     const index = context.playlists.findIndex(
       (item) => item.path === payload.from.path
     );
-    context.playlists[index] = payload.to;
+
+    const copyTo = { ...payload.to };
+    copyTo.cover = null;
+    context.playlists[index] = copyTo;
   },
 };
 

--- a/src/store/playlist.ts
+++ b/src/store/playlist.ts
@@ -15,15 +15,22 @@ const getters = {
   ...make.getters(state),
 };
 
+function emptyCoverCopy(playlist: PlaylistLocal): PlaylistLocal {
+  const copy = { ...playlist };
+  copy.cover = null;
+  return copy;
+}
+
 const mutations = {
   ...make.mutations(state),
+  SET_PLAYLISTS(context: PlaylistStoreState, playlists: PlaylistLocal[]) {
+    context.playlists = (playlists ?? []).map((p) => emptyCoverCopy(p));
+  },
   addPlaylist(
     context: PlaylistStoreState,
     payload: { playlist: PlaylistLocal }
   ) {
-    const copy = { ...payload.playlist };
-    copy.cover = null;
-    context.playlists.push(copy);
+    context.playlists.push(emptyCoverCopy(payload.playlist));
   },
   removePlaylist(
     context: PlaylistStoreState,
@@ -40,10 +47,7 @@ const mutations = {
     const index = context.playlists.findIndex(
       (item) => item.path === payload.from.path
     );
-
-    const copyTo = { ...payload.to };
-    copyTo.cover = null;
-    context.playlists[index] = copyTo;
+    context.playlists[index] = emptyCoverCopy(payload.to);
   },
 };
 


### PR DESCRIPTION
Before this PR, each playlist's cover were cached (so the whole image) which explain why beatlist was slow when querying this cache. With this PR I force the playlist's cover to be null in the cache and read it from the playlist's file itself.

This also include a small script to nullify all current cover in the cache on upgrade.